### PR TITLE
bugfix - fix softdelete detection

### DIFF
--- a/src/Http/Controllers/AuditController.php
+++ b/src/Http/Controllers/AuditController.php
@@ -55,8 +55,7 @@ class AuditController
     protected function loadRecord($resourceName, $resourceId)
     {
         $model = Nova::modelInstanceForKey($resourceName);
-
-        return in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($model))
+        return method_exists($model, "trashed")
             ? $model::withTrashed()->find($resourceId)
             : $model->find($resourceId);
     }


### PR DESCRIPTION
in version 1.0.9 you rely on class_uses method in \Devpartners\AuditableLog\Http\Controllers\AuditController::loadRecord

```
class_uses ( mixed $class , bool $autoload = true ) : array
This function returns an array with the names of the traits that the given class uses. This does however not include any traits used by a parent class.
```

however my models are extending a base model which uses the soft delete trait. But the actual model in itself does not... So this uses_class is not very good.

method_exists on  WithTrashed will also not yield any results as that method is a magic method... but not magic in the sense of is_callable.
So we have to make the assumption that when the method trashed() exists the withTrashed will also be there...
