### PR TITLE
Remove all global scopes instead of just trashed

### DIFF
--- a/src/Http/Controllers/AuditController.php
+++ b/src/Http/Controllers/AuditController.php
@@ -58,8 +58,7 @@ class AuditController
     protected function loadRecord($resourceName, $resourceId)
     {
         $model = Nova::modelInstanceForKey($resourceName);
-        return method_exists($model, "trashed")
-            ? $model::withTrashed()->find($resourceId)
-            : $model->find($resourceId);
+
+        return $model->withoutGlobalScopes()->find($resourceId);
     }
 }


### PR DESCRIPTION
Right now the `loadRecord` only removes the `trashed` global scope when it is present.

However, this causes a problem for other records with Global Scopes. It seems Nova itself will ignore these scopes when serving a detail page, so it means you can view records that then fail when you click on auditable log with the following error when the resource is not properly loaded.

```log
Too few arguments to function Devpartners\AuditableLog\ToolServiceProvider::Devpartners\AuditableLog\{closure}(),
1 passed in {{repo}}/vendor/laravel/framework/src/Illuminate/Auth/Access/Gate.php on line 548 and exactly 2 expected
```

As a side effect, the `withoutGlobalScopes` also removes the trashed scope, so you can remove the ternary.

Let me know if you'd like me to take another approach, but I think this is fine with how Nova already works.
